### PR TITLE
Use clean API function to get the theme path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,5 @@ documentation):
 
     # Below the definition of html_theme_path:
     import catkin_sphinx
-    html_theme_path.append(os.path.join(os.path.dirname(catkin_sphinx.__file__),
-                                        'theme'))
+    html_theme_path = [catkin_sphinx.get_theme_path()]
 

--- a/src/catkin_sphinx/__init__.py
+++ b/src/catkin_sphinx/__init__.py
@@ -1,0 +1,7 @@
+import os
+
+
+def get_theme_path():
+    """Returns the path to the themes bundled with catkin_sphinx"""
+    return os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                        'theme')


### PR DESCRIPTION
change is backward compatible, since theme did not move. I considered creating a python module instead, which is a bit cleaner and thus more future proof, not sure whether that's worth it.