### PR TITLE
also support sphinx > 1.4.0

### DIFF
--- a/src/catkin_sphinx/cmake.py
+++ b/src/catkin_sphinx/cmake.py
@@ -13,15 +13,16 @@
 import re
 
 from docutils import nodes
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 
 from sphinx import addnodes
+from sphinx import version_info
 from sphinx.roles import XRefRole
 from sphinx.locale import l_, _
 from sphinx.domains import Domain, ObjType, Index
 from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
-from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
 
 
@@ -238,8 +239,10 @@ class CMakeObject(ObjectDescription):
 
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
-            self.indexnode['entries'].append(('single', indextext,
-                                              fullname, ''))
+            args = ('single', indextext, fullname, '')
+            if version_info > (1, 4, 0, '', 0):
+                args = args + (None, )
+            self.indexnode['entries'].append(args)
 
     def before_content(self):
         # needed for automatic qualification of members (reset in subclasses)


### PR DESCRIPTION
Fix issues in melodic doc jobs which use a newer version of sphinx.

* Before on Melodic: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdoc__catkin__ubuntu_bionic_amd64&build=2)](http://build.ros.org/job/Mdoc__catkin__ubuntu_bionic_amd64/2/) 59 warnings
* After on Melodic: [![Build Status](http://build.ros.org/buildStatus/icon?job=Mdoc__catkin__ubuntu_bionic_amd64&build=3)](http://build.ros.org/job/Mdoc__catkin__ubuntu_bionic_amd64/3/) 1 warning addressed in ros-infrastructure/rosdoc_lite#79

* Still working in Indigo: [![Build Status](http://build.ros.org/buildStatus/icon?job=Idoc__catkin__ubuntu_trusty_amd64&build=30)](http://build.ros.org/job/Idoc__catkin__ubuntu_trusty_amd64/30/)