### PR TITLE
List 'ROS Infrastructure Team' as the package maintainer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,12 @@ setup(
   author = "Troy Straszheim, Issac Trotts, William Woodall",
   author_email = "straszheim@willowgarage.com, itrotts@willowgarage.com, william@openrobotics.org",
   maintainer="ROS Infrastructure Team",
+  project_urls={
+    'Source code':
+    'https://github.com/ros-infrastructure/catkin-sphinx',
+    'Issue tracker':
+    'https://github.com/ros-infrastructure/catkin-sphinx/issues',
+  },
   url="http://www.ros.org/",
   download_url="http://pr.willowgarage.com/downloads/catkin_sphinx/",
   keywords=["ROS"],

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,9 @@ setup(
     ]
   },
   package_dir={'catkin_sphinx': 'src/catkin_sphinx'},
-  # The original author was Troy Straszheim
-  # Previous maintainers include: Issac Trotts
-  # The current maintainer is William Woodall
-  author="William Woodall",
-  author_email="william@osrfoundation.org",
+  author = "Troy Straszheim, Issac Trotts, William Woodall",
+  author_email = "straszheim@willowgarage.com, itrotts@willowgarage.com, william@openrobotics.org",
+  maintainer="ROS Infrastructure Team",
   url="http://www.ros.org/",
   download_url="http://pr.willowgarage.com/downloads/catkin_sphinx/",
   keywords=["ROS"],


### PR DESCRIPTION
This package is currently maintained by members of the ROS infrastructure team at Open Robotics.

I re-added previous others to the `authors` field rather than listing them in a comment.