### PR TITLE
Add python3 targets for bullseye and bookworm

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,5 +4,5 @@ Depends3: python3-sphinx
 Conflicts: python3-catkin-sphinx
 Conflicts3: python-catkin-sphinx
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
-Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster bullseye bookworm
 X-Python3-Version: >= 3.4


### PR DESCRIPTION
This will need a rerelease or manual flood to fill it out.