### PR TITLE
Fix build warning for invalid path in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-recursive-include theme *
+recursive-include src/catkin_sphinx/theme *
 


### PR DESCRIPTION
Resolves:
```
warning: no files found matching '*' under directory 'theme'
```