### PR TITLE
Add some basic smoke tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+---
+name: Run tests
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ['master']
+  pull_request:
+
+jobs:
+  pytest:
+    uses: ros-infrastructure/ci/.github/workflows/pytest.yaml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: yamllint -f github .

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/.coverage
 MANIFEST
 dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[tool:pytest]
+junit_suite_name = catkin-sphinx
+markers =
+  sphinx
+
+[coverage:run]
+source = catkin_sphinx

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,11 @@ setup(
   description="Sphinx extension for Catkin projects",
   long_description="Sphinx extension for Catkin projects that provides a "
                    "custom ROS theme and a Sphinx domain for cmake.",
-  license="BSD"
+  license="BSD",
+  extras_require={
+    'test': [
+      'pytest',
+      'sphinx',
+    ],
+  },
 )

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))),
+    'src'))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+from sphinx.testing.path import path
+
+pytest_plugins = (
+    'sphinx.testing.fixtures',
+)
+
+
+@pytest.fixture(scope='session')
+def rootdir():
+    return path(__file__).parent.abspath() / 'roots'

--- a/test/roots/test-cmake-extension/conf.py
+++ b/test/roots/test-cmake-extension/conf.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+import catkin_sphinx
+
+
+project = 'test_cmake_extension'
+
+sys.path.append(str(Path(catkin_sphinx.__file__).parent.resolve()))
+
+extensions = ['cmake']

--- a/test/roots/test-sh-lexer-extension/conf.py
+++ b/test/roots/test-sh-lexer-extension/conf.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+import sys
+
+import catkin_sphinx
+
+
+project = 'test_sh_lexer'
+
+sys.path.append(str(Path(catkin_sphinx.__file__).parent.resolve()))
+
+extensions = ['ShLexer']

--- a/test/test_cmake_extension.py
+++ b/test/test_cmake_extension.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.sphinx(testroot='cmake-extension')
+def test_cmake_extension_setup(app):
+    pass

--- a/test/test_sh_lexer_extension.py
+++ b/test/test_sh_lexer_extension.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.mark.sphinx(testroot='sh-lexer-extension')
+def test_sh_lexer_setup(app):
+    pass

--- a/test/test_theme_path.py
+++ b/test/test_theme_path.py
@@ -1,0 +1,6 @@
+import catkin_sphinx
+
+
+def test_theme_path():
+    res = catkin_sphinx.get_theme_path()
+    assert res


### PR DESCRIPTION
This package has been broken in Fedora for quite some time. Due to the lack of any tests, nobody with any power to fix the problem knew about it.

This change add some very simple tests using Sphinx's own pytest framework to validate that we can load the extensions defined here. Better late than never, right?